### PR TITLE
Fix typo to avoid build error

### DIFF
--- a/mycobot-transponder.ino
+++ b/mycobot-transponder.ino
@@ -42,7 +42,7 @@ const int16_t COMMAND_HEIGHT = 26 * 2;
 const int32_t COMMAND_NAME_X_POS = 16;
 const int32_t COMMAND_NAME_Y_POS = 26;
 const uint8_t COMMAND_FONT_SIZE = 4;
-const uint8_t COMMAND_DATUM TL_DATUM;
+const uint8_t COMMAND_DATUM = TL_DATUM;
 const uint32_t COMMAND_COLOR = TFT_WHITE;
 const uint32_t COMMAND_BG_COLOR = TFT_BLACK;
 const char *COMMAND_LABEL = "Send:";


### PR DESCRIPTION
PlatformIOでビルドしようとしたところ、以下のエラーが出てしまっていたので修正しました。

```
M5Stack/src/utility/In_eSPI.h:494:18: error: expected initializer before numeric constant
 #define TL_DATUM 0 // Top left (default)
                  ^
```