### PR TITLE
SET_BASIC_OUTPUTコマンド（0xA0）のサポート

### DIFF
--- a/src/MyCobot.cpp
+++ b/src/MyCobot.cpp
@@ -188,6 +188,8 @@ const char *const MyCobotParser::getCommandName(int cmd)
     return "Is Gripper Moving?";
   case SET_LED:
     return "Set LED";
+  case SET_BASIC_OUTPUT:
+    return "Set Basic Output";
   default:
     return "Unknown";
   };

--- a/src/MyCobot.h
+++ b/src/MyCobot.h
@@ -81,6 +81,9 @@ enum CommandCode
   SET_GRIPPER_INI = 0x68,
   IS_GRIPPER_MOVING = 0x69,
   SET_LED = 0x6a,
+
+  // Basic
+  SET_BASIC_OUTPUT = 0xa0,
 };
 
 class MyCobotTransponder

--- a/src/Transponder.cpp
+++ b/src/Transponder.cpp
@@ -181,7 +181,7 @@ void Transponder::updateUI(byte b)
     }
 }
 
-void Transponder::parseSetBasic(void) {
+void Transponder::parseSetBasicOutput(void) {
     uint8_t b = 0;
     uint8_t pinNo = 0;
     uint8_t pinData = 0;
@@ -240,7 +240,7 @@ void Transponder::update(void)
         }
         if (b == SET_BASIC_OUTPUT)
         {
-            parseSetBasic();
+            parseSetBasicOutput();
         }
     }
 }

--- a/src/Transponder.h
+++ b/src/Transponder.h
@@ -56,6 +56,8 @@ public:
     virtual void update(void);
 
 protected:
+    virtual void parseSetBasic(void);
+    virtual void updateUI(byte b);
     virtual bool readDumped(void);
 
 private:

--- a/src/Transponder.h
+++ b/src/Transponder.h
@@ -56,7 +56,7 @@ public:
     virtual void update(void);
 
 protected:
-    virtual void parseSetBasic(void);
+    virtual void parseSetBasicOutput(void);
     virtual void updateUI(byte b);
     virtual bool readDumped(void);
 


### PR DESCRIPTION
Suction Pumpを使えるように`SET_BASIC_OUTPUT`コマンド（0xA0）をサポートした。
Basicが`SET_BASIC_OUTPUT`コマンドを受信したら，ATOMに送らずにBasicで`digitalWrite()`を実行する。
